### PR TITLE
Offer QStringRef API for packageId decoding functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,15 @@ set(QPACKAGEKIT_VERSION_SUFFIX "${VERSION_SUFFIX}")
 set(QPACKAGEKIT_API_LEVEL "0")
 set(QPACKAGEKIT_VERSION "${QPACKAGEKIT_VERSION_MAJOR}.${QPACKAGEKIT_VERSION_MINOR}.${QPACKAGEKIT_VERSION_PATCH}")
 
+add_definitions(-DQT_NO_CAST_TO_ASCII
+                -DQT_NO_CAST_FROM_ASCII
+                -DQT_NO_URL_CAST_FROM_STRING
+                -DQT_NO_CAST_FROM_BYTEARRAY
+                -DQT_NO_SIGNALS_SLOTS_KEYWORDS
+                -DQT_USE_FAST_OPERATOR_PLUS
+                -DQT_USE_QSTRINGBUILDER
+               )
+
 # Forbid in-tree building
 if(${CMAKE_SOURCE_DIR} MATCHES ${CMAKE_BINARY_DIR})
       message(STATUS "Please do an out-of-tree build:")

--- a/src/daemon.cpp
+++ b/src/daemon.cpp
@@ -59,7 +59,7 @@ Daemon::Daemon(QObject *parent) :
                                          SLOT(propertiesChanged(QString,QVariantMap,QStringList)));
 }
 
-void DaemonPrivate::setupSignal(const QString &signal, bool connect)
+void DaemonPrivate::setupSignal(const QByteArray &signal, bool connect)
 {
     Q_Q(Daemon);
 
@@ -89,7 +89,7 @@ void DaemonPrivate::setupSignal(const QString &signal, bool connect)
     }
 }
 
-void Daemon::connectNotify(const char *signal)
+void Daemon::connectNotify(const QByteArray &signal)
 {
     Q_D(Daemon);
     if (!d->connectedSignals.contains(signal) && d->daemon) {
@@ -105,7 +105,7 @@ void Daemon::connectNotify(const QMetaMethod &signal)
                   .arg(QLatin1String(signal.methodSignature())).toLatin1());
 }
 
-void Daemon::disconnectNotify(const char *signal)
+void Daemon::disconnectNotify(const QByteArray &signal)
 {
     Q_D(Daemon);
     if (d->connectedSignals.contains(signal)) {

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -824,7 +824,7 @@ protected:
      * \attention Make sure to call this method in inherited classes
      * otherwise no signals will be emitted
      */
-    virtual void connectNotify(const char *signal);
+    virtual void connectNotify(const QByteArray &signal);
     virtual void connectNotify(const QMetaMethod &signal);
 
     /**
@@ -832,7 +832,7 @@ protected:
      * \attention Make sure to call this method in inherited classes
      * otherwise no signals will be disconnected
      */
-    virtual void disconnectNotify(const char *signal);
+    virtual void disconnectNotify(const QByteArray &signal);
     virtual void disconnectNotify(const QMetaMethod &signal);
 
     DaemonPrivate * const d_ptr;

--- a/src/daemonprivate.cpp
+++ b/src/daemonprivate.cpp
@@ -81,7 +81,7 @@ void DaemonPrivate::getAllProperties(bool sync)
                                                           QLatin1String(PK_PATH),
                                                           QLatin1String(DBUS_PROPERTIES),
                                                           QLatin1String("GetAll"));
-    message << PK_NAME;
+    message << QLatin1String(PK_NAME);
     if (sync) {
         QDBusReply<QVariantMap> reply = QDBusConnection::systemBus().call(message);
         if (reply.isValid()) {

--- a/src/daemonprivate.h
+++ b/src/daemonprivate.h
@@ -41,9 +41,9 @@ protected:
     Daemon *q_ptr;
     ::OrgFreedesktopPackageKitInterface *daemon;
     QStringList hints;
-    QStringList connectedSignals;
+    QList<QByteArray> connectedSignals;
 
-    void setupSignal(const QString &signal, bool connect);
+    void setupSignal(const QByteArray &signal, bool connect);
     void getAllProperties(bool sync);
 
     QString backendAuthor;

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -52,7 +52,7 @@ Transaction::Transaction(const QDBusObjectPath &tid)
     d->setup(tid);
 }
 
-void Transaction::connectNotify(const char *signal)
+void Transaction::connectNotify(const QByteArray &signal)
 {
     Q_D(Transaction);
     if (!d->connectedSignals.contains(signal) && d->p) {
@@ -64,11 +64,10 @@ void Transaction::connectNotify(const char *signal)
 void Transaction::connectNotify(const QMetaMethod &signal)
 {
     // ugly but recommended way to convert a methodSignature to a SIGNAL
-    connectNotify(QStringLiteral("2%1")
-                  .arg(QLatin1String(signal.methodSignature())).toLatin1());
+    connectNotify('2'+signal.methodSignature());
 }
 
-void Transaction::disconnectNotify(const char *signal)
+void Transaction::disconnectNotify(const QByteArray &signal)
 {
     Q_D(Transaction);
     if (d->connectedSignals.contains(signal)) {
@@ -82,8 +81,7 @@ void Transaction::disconnectNotify(const char *signal)
 void Transaction::disconnectNotify(const QMetaMethod &signal)
 {
     // ugly but recommended way to convert a methodSignature to a SIGNAL
-    disconnectNotify(QStringLiteral("2%1")
-                     .arg(QLatin1String(signal.methodSignature())).toLatin1());
+    disconnectNotify('2'+signal.methodSignature());
 }
 
 Transaction::Transaction(TransactionPrivate *d)
@@ -91,7 +89,7 @@ Transaction::Transaction(TransactionPrivate *d)
 {
 }
 
-void TransactionPrivate::setupSignal(const QString &signal, bool connect)
+void TransactionPrivate::setupSignal(const QByteArray &signal, bool connect)
 {
     Q_Q(Transaction);
 
@@ -150,9 +148,9 @@ void TransactionPrivate::setupSignal(const QString &signal, bool connect)
 
     if (signalToConnect && memberToConnect) {
         if (connect) {
-            q->connect(p, signalToConnect, memberToConnect);
+            QObject::connect(p, signalToConnect, q, memberToConnect);
         } else {
-            p->disconnect(signalToConnect, q, memberToConnect);
+            QObject::disconnect(p, signalToConnect, q, memberToConnect);
         }
     }
 }

--- a/src/transaction.h
+++ b/src/transaction.h
@@ -844,7 +844,7 @@ protected:
      * \attention Make sure to call this method in inherited classes
      * otherwise no signals will be emitted
      */
-    virtual void connectNotify(const char *signal);
+    void connectNotify(const QByteArray& signal);
     virtual void connectNotify(const QMetaMethod &signal);
 
     /**
@@ -852,7 +852,7 @@ protected:
      * \attention Make sure to call this method in inherited classes
      * otherwise no signals will be disconnected
      */
-    virtual void disconnectNotify(const char *signal);
+    virtual void disconnectNotify(const QByteArray &signal);
     virtual void disconnectNotify(const QMetaMethod &signal);
 
     TransactionPrivate * const d_ptr;

--- a/src/transactionprivate.cpp
+++ b/src/transactionprivate.cpp
@@ -61,7 +61,7 @@ void TransactionPrivate::setup(const QDBusObjectPath &transactionId)
                                                           tid.path(),
                                                           QLatin1String(DBUS_PROPERTIES),
                                                           QLatin1String("GetAll"));
-    message << PK_TRANSACTION_INTERFACE;
+    message << QLatin1String(PK_TRANSACTION_INTERFACE);
     QDBusConnection::systemBus().callWithCallback(message,
                                                   q,
                                                   SLOT(updateProperties(QVariantMap)));
@@ -74,9 +74,8 @@ void TransactionPrivate::setup(const QDBusObjectPath &transactionId)
                                          q,
                                          SLOT(propertiesChanged(QString,QVariantMap,QStringList)));
 
-    QStringList currentSignals = connectedSignals;
-    currentSignals.removeDuplicates();
-    foreach (const QString &signal, currentSignals) {
+    const QSet<QByteArray> currentSignals = connectedSignals.toSet();
+    foreach (const QByteArray &signal, currentSignals) {
         setupSignal(signal, true);
     }
 

--- a/src/transactionprivate.h
+++ b/src/transactionprivate.h
@@ -47,7 +47,7 @@ protected:
     QDBusObjectPath tid;
     ::OrgFreedesktopPackageKitTransactionInterface* p = 0;
     Transaction *q_ptr;
-    QStringList connectedSignals;
+    QList<QByteArray> connectedSignals;
 
     bool sentFinished = false;
     bool allowCancel = false;
@@ -88,7 +88,11 @@ protected:
     QString data;
     QString cmdline;
 
-    void setupSignal(const QString &signal, bool connect);
+    void setupSignal(const QByteArray &signal, bool connect);
+
+private:
+    template <typename Func1, typename Func2>
+    void processConnect(bool connect, Func1 signal, Func2 slot);
 
 protected Q_SLOTS:
     void createTransactionFinished(QDBusPendingCallWatcher *call);


### PR DESCRIPTION
We don't own the QString and it can be useful to provide such an API
for the cases where we're really passing the object around rather
than keeping it. In fact, the common thing to do ends up being keeping
the whole packageId, in case some other of the data is needed later.
Also since we get to simplify the implementation a bit, leverage it
by making use of the new splitting function from the current API.