### PR TITLE
Make sure PackageKit-Qt consumers can link to it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # CMakeLists for PackageKit-Qt
 project(packagekit-qt)
 
-cmake_minimum_required(VERSION 2.8.6 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
 find_package(PkgConfig REQUIRED)
 
 # Used to set installation paths

--- a/src/modules/packagekit-qt-config.cmake.in
+++ b/src/modules/packagekit-qt-config.cmake.in
@@ -7,4 +7,6 @@ SET(prefix "@CMAKE_INSTALL_PREFIX@")
 SET(exec_prefix "@CMAKE_INSTALL_PREFIX@")
 SET(PackageKitQt5_LIBRARIES "PK::packagekitqt5")
 
+find_dependency(Qt5DBus 5.6 REQUIRED)
+
 include("${CMAKE_CURRENT_LIST_DIR}/PackageKitQtTargets.cmake")


### PR DESCRIPTION
We need to search for Qt5::DBus, otherwise projects that don't depend on it fail to compile.