### PR TITLE
Reintroduce upgradeSystem()

### DIFF
--- a/src/daemon.cpp
+++ b/src/daemon.cpp
@@ -422,6 +422,16 @@ Transaction *Daemon::getDistroUpgrades()
     return ret;
 }
 
+Transaction *Daemon::upgradeSystem(const QString &distroId, Transaction::UpgradeKind kind, Transaction::TransactionFlags flags)
+{
+    Transaction *ret = new Transaction;
+    ret->d_ptr->role = Transaction::RoleUpgradeSystem;
+    ret->d_ptr->upgradeDistroId = distroId;
+    ret->d_ptr->upgradeKind = kind;
+    ret->d_ptr->transactionFlags = flags;
+    return ret;
+}
+
 Transaction *Daemon::installFiles(const QStringList &files, Transaction::TransactionFlags flags)
 {
     Transaction *ret = new Transaction;

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -523,6 +523,30 @@ public:
     static Transaction *getDistroUpgrades();
 
     /**
+     * Updates the whole system
+     *
+     * This method perfoms a distribution upgrade to the
+     * specified version.
+     *
+     * The \p type of upgrade, e.g. minimal, default or complete.
+     * Minimal upgrades will download the smallest amount of data
+     * before launching a installer.
+     * The default is to download enough data to launch a full
+     * graphical installer, but a complete upgrade will be
+     * required if there is no internet access during install time.
+     *
+     * \note This method typically emits
+     * \li progress()
+     * \li status()
+     * \li error()
+     * \li package()
+     *
+     * \warning check \sa errorCode() signal to know if it the call has any error
+     */
+    static Transaction *upgradeSystem(const QString &distroId, Transaction::UpgradeKind kind,
+                                      Transaction::TransactionFlags flags = Transaction::TransactionFlagOnlyTrusted);
+
+    /**
      * \brief Installs the local packages \p files
      *
      * \p onlyTrusted indicate if the packages are signed by a trusted authority

--- a/src/transaction.h
+++ b/src/transaction.h
@@ -130,7 +130,8 @@ public:
         RoleRepairSystem,       // Since 0.7.2
         RoleGetDetailsLocal,    // Since 0.8.17
         RoleGetFilesLocal,      // Since 0.9.1
-        RoleRepoRemove          // Since 0.9.1
+        RoleRepoRemove,         // Since 0.9.1
+        RoleUpgradeSystem       // since 1.0.11
     };
     Q_ENUM(Role)
     typedef Bitfield Roles;
@@ -355,7 +356,19 @@ public:
 
     /**
      * Describes the type of distribution upgrade to perform
-     * \sa upgradeSystem()
+     * \sa Daemon::upgradeSystem()
+      */
+    enum UpgradeKind {
+        UpgradeKindUnknown,
+        UpgradeKindMinimal,
+        UpgradeKindDefault,
+        UpgradeKindComplete
+    };
+    Q_ENUM(UpgradeKind)
+
+    /**
+     * Describes the type of distribution upgrade to perform
+     * \sa Daemon::upgradeSystem()
      */
     enum TransactionFlag {
         TransactionFlagNone         = 1 << 0, // Since: 0.8.1
@@ -909,5 +922,6 @@ Q_DECLARE_METATYPE(PackageKit::Transaction::SigType)
 Q_DECLARE_METATYPE(PackageKit::Transaction::Filter)
 Q_DECLARE_METATYPE(PackageKit::Transaction::TransactionFlags)
 Q_DECLARE_METATYPE(PackageKit::Transaction::Filters)
+Q_DECLARE_METATYPE(PackageKit::Transaction::UpgradeKind)
 
 #endif

--- a/src/transactionprivate.cpp
+++ b/src/transactionprivate.cpp
@@ -180,6 +180,9 @@ void TransactionPrivate::runQueuedTransaction()
     case Transaction::RoleRepoRemove:
         reply = p->RepoRemove(transactionFlags, repoId, autoremove);
         break;
+    case Transaction::RoleUpgradeSystem:
+        reply = p->UpgradeSystem(transactionFlags, upgradeDistroId, upgradeKind);
+        break;
     default:
         break;
     }

--- a/src/transactionprivate.h
+++ b/src/transactionprivate.h
@@ -87,6 +87,9 @@ protected:
     QString data;
     QString cmdline;
 
+    QString upgradeDistroId;
+    Transaction::UpgradeKind upgradeKind;
+
     void setupSignal(const QMetaMethod &signal, bool connect);
 
 private:


### PR DESCRIPTION
Was removed earlier to follow PackageKit removal, but since then
PackageKit added it back.