### PR TITLE
Make Transaction deletion match better what is really happening

### DIFF
--- a/src/transaction.h
+++ b/src/transaction.h
@@ -45,7 +45,7 @@ class Details;
 * A Transaction is created whenever you do an asynchronous action (for example a Search, Install...).
 * This class allows you to monitor and control the flow of the action.
 *
-* You should delete the transaction after finished() is emitted
+* Transaction will be automatically deleted after finished() is emitted
 *
 * \sa Daemon
 */


### PR DESCRIPTION
Old text could have been read as allowing something like delete sender()
in signal handler which wouldn't have worked properly.

The transaction will be deleted when PackageKit signals Destroy or there's
an error, so unless pointers are protected with QPointer or similar,
all the bets are off for pointer references after finished().

Was also thinking if TransactionPrivate::finished() should just always do q->deleteLater()