### PR TITLE
Avoid deadlock on disconnecting signals

### DIFF
--- a/src/daemon.cpp
+++ b/src/daemon.cpp
@@ -59,7 +59,7 @@ Daemon::Daemon(QObject *parent) :
                                          SLOT(propertiesChanged(QString,QVariantMap,QStringList)));
 }
 
-void DaemonPrivate::setupSignal(const QMetaMethod &signal, bool connect)
+void DaemonPrivate::setupSignal(const QMetaMethod &signal)
 {
     Q_Q(Daemon);
 
@@ -81,11 +81,7 @@ void DaemonPrivate::setupSignal(const QMetaMethod &signal, bool connect)
     }
 
     if (signalToConnect && memberToConnect) {
-        if (connect) {
-            QObject::connect(daemon, signalToConnect, q, memberToConnect);
-        } else {
-            QObject::disconnect(daemon, signalToConnect, q, memberToConnect);
-        }
+        QObject::connect(daemon, signalToConnect, q, memberToConnect);
     }
 }
 
@@ -93,20 +89,14 @@ void Daemon::connectNotify(const QMetaMethod &signal)
 {
     Q_D(Daemon);
     if (!d->connectedSignals.contains(signal) && d->daemon) {
-        d->setupSignal(signal, true);
+        d->setupSignal(signal);
+        d->connectedSignals << signal;
     }
-    d->connectedSignals << signal;
 }
 
 void Daemon::disconnectNotify(const QMetaMethod &signal)
 {
-    Q_D(Daemon);
-    if (d->connectedSignals.contains(signal)) {
-        d->connectedSignals.removeOne(signal);
-        if (d->daemon && !d->connectedSignals.contains(signal)) {
-            d->setupSignal(signal, false);
-        }
-    }
+    QObject::disconnectNotify(signal);
 }
 
 Daemon::~Daemon()

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -851,9 +851,7 @@ protected:
     void connectNotify(const QMetaMethod &signal) override;
 
     /**
-     * This method disconnects from DBus signals
      * \attention Make sure to call this method in inherited classes
-     * otherwise no signals will be disconnected
      */
     void disconnectNotify(const QMetaMethod &signal) override;
 

--- a/src/daemonprivate.h
+++ b/src/daemonprivate.h
@@ -43,7 +43,7 @@ protected:
     QStringList hints;
     QList<QMetaMethod> connectedSignals;
 
-    void setupSignal(const QMetaMethod &signal, bool connect);
+    void setupSignal(const QMetaMethod &signal);
     void getAllProperties(bool sync);
 
     QString backendAuthor;

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -55,21 +55,18 @@ Transaction::Transaction(const QDBusObjectPath &tid)
 void Transaction::connectNotify(const QMetaMethod &signal)
 {
     Q_D(Transaction);
-    if (!d->connectedSignals.contains(signal) && d->p) {
-        d->setupSignal(signal, true);
+    if (!d->connectedSignals.contains(signal)) {
+        d->connectedSignals << signal;
+
+        if (d->p) {
+            d->setupSignal(signal);
+        }
     }
-    d->connectedSignals << signal;
 }
 
 void Transaction::disconnectNotify(const QMetaMethod &signal)
 {
-    Q_D(Transaction);
-    if (d->connectedSignals.contains(signal)) {
-        d->connectedSignals.removeOne(signal);
-        if (d->p && !d->connectedSignals.contains(signal)) {
-            d->setupSignal(signal, false);
-        }
-    }
+    QObject::disconnectNotify(signal);
 }
 
 Transaction::Transaction(TransactionPrivate *d)
@@ -77,7 +74,7 @@ Transaction::Transaction(TransactionPrivate *d)
 {
 }
 
-void TransactionPrivate::setupSignal(const QMetaMethod &signal, bool connect)
+void TransactionPrivate::setupSignal(const QMetaMethod &signal)
 {
     Q_Q(Transaction);
 
@@ -135,11 +132,7 @@ void TransactionPrivate::setupSignal(const QMetaMethod &signal, bool connect)
     }
 
     if (signalToConnect && memberToConnect) {
-        if (connect) {
-            QObject::connect(p, signalToConnect, q, memberToConnect);
-        } else {
-            QObject::disconnect(p, signalToConnect, q, memberToConnect);
-        }
+        QObject::connect(p, signalToConnect, q, memberToConnect);
     }
 }
 

--- a/src/transaction.h
+++ b/src/transaction.h
@@ -859,9 +859,7 @@ protected:
     void connectNotify(const QMetaMethod &signal) override;
 
     /**
-     * This method disconnects from DBus signals
      * \attention Make sure to call this method in inherited classes
-     * otherwise no signals will be disconnected
      */
     void disconnectNotify(const QMetaMethod &signal) override;
 

--- a/src/transactionprivate.cpp
+++ b/src/transactionprivate.cpp
@@ -74,7 +74,7 @@ void TransactionPrivate::setup(const QDBusObjectPath &transactionId)
                                          SLOT(propertiesChanged(QString,QVariantMap,QStringList)));
 
     foreach (const QMetaMethod &signal, connectedSignals) {
-        setupSignal(signal, true);
+        setupSignal(signal);
     }
 
     // Execute pending call

--- a/src/transactionprivate.h
+++ b/src/transactionprivate.h
@@ -23,7 +23,7 @@
 #define PACKAGEKIT_TRANSACTION_PRIVATE_H
 
 #include <QString>
-#include <QHash>
+#include <QList>
 #include <QStringList>
 #include <QDBusPendingCallWatcher>
 
@@ -90,7 +90,7 @@ protected:
     QString upgradeDistroId;
     Transaction::UpgradeKind upgradeKind;
 
-    void setupSignal(const QMetaMethod &signal, bool connect);
+    void setupSignal(const QMetaMethod &signal);
 
 private:
     template <typename Func1, typename Func2>


### PR DESCRIPTION
QObject::disconnectNotify() documentation:

"[...] This function may also be called with a QObject internal mutex
locked. It is therefore not allowed to re-enter any of any QObject
functions from your reimplementation [...]"

Now just avoiding signal disconnection from proxy. Assuming quite rare
code anyway does disconnects on transactions, and even if does, the
benefit would be questionable.