### PR TITLE
Delete the transactions when they are done

### DIFF
--- a/src/transactionprivate.cpp
+++ b/src/transactionprivate.cpp
@@ -252,6 +252,7 @@ void TransactionPrivate::finished(uint exitCode, uint runtime)
     Q_Q(Transaction);
     q->finished(static_cast<Transaction::Exit>(exitCode), runtime);
     sentFinished = true;
+    q->deleteLater();
 }
 
 void TransactionPrivate::destroy()


### PR DESCRIPTION
There's no reason to keep them alive and we make sure implementations
aren't listing them. Furthermore, it gives the possibility to remove the
logic to clean them up which is good in itself.