### PR TITLE
Map DBusError::AccessDenied to Transaction::ErrorNotAuthorized

### DIFF
--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -46,7 +46,10 @@ Transaction::Transaction()
     {
         QDBusPendingReply<QDBusObjectPath> reply = *call;
         if (reply.isError()) {
-            errorCode(Transaction::ErrorInternalError, reply.error().message());
+            QDBusError error = reply.error();
+            Transaction::Error transactionError = error.type() == QDBusError::AccessDenied ? Transaction::ErrorNotAuthorized
+                                                                                           : Transaction::ErrorInternalError;
+            errorCode(transactionError, error.message());
             d->finished(Transaction::ExitFailed, 0);
             d->destroy();
         } else {

--- a/src/transactionprivate.cpp
+++ b/src/transactionprivate.cpp
@@ -193,7 +193,10 @@ void TransactionPrivate::runQueuedTransaction()
                q, [this, q] (QDBusPendingCallWatcher *call) {
         QDBusPendingReply<> reply = *call;
         if (reply.isError()) {
-            q->errorCode(Transaction::ErrorInternalError, reply.error().message());
+            QDBusError error = reply.error();
+            Transaction::Error transactionError = error.type() == QDBusError::AccessDenied ? Transaction::ErrorNotAuthorized
+                                                                                           : Transaction::ErrorInternalError;
+            q->errorCode(transactionError, error.message());
             finished(Transaction::ExitFailed, 0);
             destroy();
         }


### PR DESCRIPTION
This commit maps the DBusError:AccessDenied to Transaction::ErrorNotAuthorized
that seems to closest match. The best would be if the QDBusError itself
would be passed to the errorCode signal but I did not want to alter
the API.